### PR TITLE
fix(Load Html): setState on unmounted component

### DIFF
--- a/expo-leaflet/ExpoLeaflet.tsx
+++ b/expo-leaflet/ExpoLeaflet.tsx
@@ -21,6 +21,8 @@ export const ExpoLeaflet = ({
   const [isWebviewReady, setWebviewReady] = useState(false)
   const previousPropsRef = useRef<Partial<LeafletMapProps>>({})
   useEffect(() => {
+    let isNotCancelled = true;
+
     const loadHtmlFile = async () => {
       try {
         const path = require(`./assets/index.html`)
@@ -29,17 +31,25 @@ export const ExpoLeaflet = ({
         const webviewContent: string = await FileSystem.readAsStringAsync(
           htmlFile.localUri!,
         )
-        setWebviewContent(webviewContent)
-        onMessage({
-          tag: 'DebugMessage',
-          message: 'WebView content loaded',
-        })
+        if (isNotCancelled) {
+          setWebviewContent(webviewContent)
+          onMessage({
+            tag: 'DebugMessage',
+            message: 'WebView content loaded',
+          })
+        }
       } catch (error) {
-        onMessage({ tag: 'Error', error })
+        if (isNotCancelled) {
+          onMessage({ tag: 'Error', error })
+        }
       }
     }
 
     loadHtmlFile().catch(() => {})
+
+    return () => {
+      isNotCancelled = false;
+    }
   }, [])
 
   useEffect(() => {


### PR DESCRIPTION
I have been facing this warning in android:

Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
    in ExpoLeaflet (created by Map)
    in RCTView (created by View)
    in View
    in StyledNativeComponent (created by Styled(View))
    in Styled(View)
    in Box
    in RCTView (created by View)
    in View
    in StyledNativeComponent (created by Styled(View))
    in Styled(View)
    in Box
    in Map

This warning is shown when i render an array of maps, for example:

{routes.map((route, index) => (
    <Map 
        key={genKey()}
        route={route as IRoute}
    </Map>
))}

these changes removed this warning, what do you think about an update?
Thanks.